### PR TITLE
Small bug fix to change status on sub_teas when sub is deactivated

### DIFF
--- a/app/models/Subscription.rb
+++ b/app/models/Subscription.rb
@@ -6,5 +6,11 @@ class Subscription < ApplicationRecord
   has_many :teas, through: :subscription_teas
   has_many :customers, through: :subscription_teas
 
+  after_update :subscription_teas_status_update, if: -> { saved_change_to_status? && !status }
   
+  private
+
+  def subscription_teas_status_update
+    subscription_teas.update_all(status: false)
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,6 +1,20 @@
 require "rails_helper"
+require "pry"
 
 RSpec.describe Subscription, type: :model do
+  before :each do
+    @sub1 = Subscription.create!(title: "Green Tea Lovers", price: 5.50, status: true, frequency: "monthly")
+    @sub2 = Subscription.create!(title: "White Tea Lovers", price: 7.50, status: true, frequency: "monthly")
+    @tea1 = Tea.create!(title: "Arizona Green Tea", description: "Plastic bottle tea", temp: 2, brew_time: 0)
+    @tea2 = Tea.create!(title: "Black Tea", description: "The rare kind", temp: 2, brew_time: 15)
+    @tea3 = Tea.create!(title: "Silver Tea", description: "The ultimate rarety!", temp: 20, brew_time: 10)
+    @test_customer = Customer.create!(first_name: "Jolly", last_name: "Green", email: "JollyGreen@gmail.com", address: "123 JollyGreen Street")
+    @test_customer2 = Customer.create!(first_name: "Big", last_name: "Red", email: "BigRed@gmail.com", address: "123 BigRed Street")
+    @test_customer.subscription_teas.create!(subscription_id: @sub2.id, tea_id: @tea1.id, customer_id: @test_customer.id, status: true)
+    @test_customer2.subscription_teas.create!(subscription_id: @sub2.id, tea_id: @tea1.id, customer_id: @test_customer2.id, status: true)
+    @test_customer2.subscription_teas.create!(subscription_id: @sub2.id, tea_id: @tea3.id, customer_id: @test_customer2.id, status: true)
+  end
+
   describe "validations" do
     it { should validate_presence_of(:title) }
     it { should validate_presence_of(:price) }
@@ -11,5 +25,19 @@ RSpec.describe Subscription, type: :model do
     it { should have_many :subscription_teas }
     it { should have_many(:teas).through(:subscription_teas) }
     it { should have_many(:customers).through(:subscription_teas) }
+  end
+
+  describe "instance methods" do
+    it 'Deactivates all subscription teas when subscription is deactivated' do
+      @sub2.subscription_teas.map do |sub_tea|
+        expect(sub_tea[:status]).to eq(true)
+      end
+
+      @sub2.update!(status: false)
+
+      @sub2.subscription_teas.map do |sub_tea|
+        expect(sub_tea[:status]).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Type of change
- [ ] New feature
- [x] Bug Fix
- [ ] New tests
Check the correct boxes
- [ ] This code broke nothing
- [ ] This code broke some stuff
- [ ] This code broke everything
Implements/Fixes:
- Description of work...
- Subscription Tea Status will be changed to False when Subscription gets deactivated.
Testing Changes:
- [x] I have fully tested my code
- [x] All tests are passing
- [ ] Some tests are failing
- [ ] All tests are failing
- [ ] No previous tests have been changed
- [ ] Some previous tests have been changed
- [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)
Checklist:
- [x] I have reviewed my code
- [x] The code will run locally
- [x] My code has no unused/commented out code
- [ ] I have commented my code, particularly in hard-to-understand areas

(Optional) What questions do you have? Anything specific you want feedback on?
-
(For Fun!) Please include a link to a gif [or add an emoji] of your feelings about this branch.
Link: